### PR TITLE
#101 Input type="file" 태그 MDL로 개선

### DIFF
--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -107,6 +107,7 @@ function addComment(e) {
 				$(".article_comment").append(comment);
 				$(".comment_new #contents").val('');
 				$("#file").val('');
+				$('#fileText').val('');
 			},
 			error: function(error) {
 				console.log(error);

--- a/src/main/resources/templates/issue/detail.html
+++ b/src/main/resources/templates/issue/detail.html
@@ -159,12 +159,13 @@
 		  <textarea class="mdl-textfield__input" id="contents" name="contents" rows=3 required></textarea>
 		  <label for="contents" class="mdl-textfield__label">Leave a comment</label>
 		</div>
-		<div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-			  <input class="mdl-textfield__input" type="file" id="file" name="file" accept=".txt,.html,.js,.zip">
-			  <label class="blind_contents mdl-textfield__label" for="file">Attachment</label>
-			  <label style="font-size:12px;">TXT, HTML, JS, ZIP 형식의 파일만 업로드 할 수 있습니다.</label>
+		<div class="mdl-textfield mdl-js-textfield mdl-textfield--file">
+		  <input class="mdl-textfield__input" placeholder="File" type="text" id="fileText" name="fileText" readonly/>
+		  <div class="mdl-button mdl-button--primary mdl-button--icon mdl-button--file">
+		    <i class="material-icons">attach_file</i><input type="file" id="file" name="file" accept=".txt,.html,.js,.zip">
+		  </div>
+		  <label style="font-size:15px;">PNG, JPG 형식의 파일만 업로드 할 수 있습니다.</label>
 		</div>
-		
 		<a class="btn_comment_complete add-comment-btn mdl-js-button mdl-js-ripple-effect mdl-button--icon">
 			<i class="material-icons" role="presentation">check</i><span class="visuallyhidden">add comment</span>
 		</a>

--- a/src/main/resources/templates/user/new.html
+++ b/src/main/resources/templates/user/new.html
@@ -41,8 +41,3 @@
 {{/partial}}
 
 {{> template}}
-<script>
-	document.getElementById("file").onchange = function () {
-		document.getElementById("fileText").value = this.files[0].name;
-	};
-</script>


### PR DESCRIPTION
 * 댓글 작성 후에도 첨부한 파일의 이름이 남아있는 문제 해결
 * Issue Comment의 input type="file" MDL 디자인 변경
 * /user/new.html에 있던 파일 첨부 관련 javascript 구문 삭제 (main.js로 통합 및 리팩토링)